### PR TITLE
Temporary fix for BNB URI decode

### DIFF
--- a/lib/rubyqrpay/generator.rb
+++ b/lib/rubyqrpay/generator.rb
@@ -12,7 +12,7 @@ module Rubyqrpay
       opts = Rubyqrpay::Validator.validate_payload(opts)
       unless opts.nil?
         payload = generation(opts)
-        percent_encode payload
+        # percent_encode payload # Temporary solution to fix invalid BNB URI decode
       end
     end
 
@@ -135,7 +135,7 @@ module Rubyqrpay
 
     def self.join_hash(hash)
       hash.map do |id, value|
-        value = value.to_s
+        value = percent_encode(value.to_s).gsub(/\%.{2}/, '')
         unless value.empty?
           len = "00#{value.size}".slice(-2..-1)
           id + len + value

--- a/lib/rubyqrpay/version.rb
+++ b/lib/rubyqrpay/version.rb
@@ -1,4 +1,4 @@
 module Rubyqrpay
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
   # compatible with ERIP API documentation from 20.05.2020
 end


### PR DESCRIPTION
The problem is when mobile banking of BNB parses QR-code, it doesn't handle URI encode for special symbols from ERIP specification, that's why we decided just to remove all encode characters from payload.